### PR TITLE
Fix for Skinned Mesh

### DIFF
--- a/examples/assets/rigTest-02.fbx
+++ b/examples/assets/rigTest-02.fbx
@@ -1,0 +1,797 @@
+; FBX 7.5.0 project file
+; Copyright (C) 1997-2010 Autodesk Inc. and/or its licensors.
+; All rights reserved.
+; ----------------------------------------------------
+
+FBXHeaderExtension:  {
+	FBXHeaderVersion: 1003
+	FBXVersion: 7500
+	CreationTimeStamp:  {
+		Version: 1000
+		Year: 2019
+		Month: 3
+		Day: 9
+		Hour: 21
+		Minute: 5
+		Second: 47
+		Millisecond: 0
+	}
+	Creator: "FBX SDK/FBX Plugins version 2016.1"
+	SceneInfo: "SceneInfo::GlobalInfo", "UserData" {
+		Type: "UserData"
+		Version: 100
+		MetaData:  {
+			Version: 100
+			Title: ""
+			Subject: ""
+			Author: ""
+			Keywords: ""
+			Revision: ""
+			Comment: ""
+		}
+		Properties70:  {
+			P: "DocumentUrl", "KString", "Url", "", "/Users/kif/pr/hong-kong-rat/export/rigTest-02.fbx"
+			P: "SrcDocumentUrl", "KString", "Url", "", "/Users/kif/pr/hong-kong-rat/export/rigTest-02.fbx"
+			P: "Original", "Compound", "", ""
+			P: "Original|ApplicationVendor", "KString", "", "", ""
+			P: "Original|ApplicationName", "KString", "", "", ""
+			P: "Original|ApplicationVersion", "KString", "", "", ""
+			P: "Original|DateTime_GMT", "DateTime", "", "", ""
+			P: "Original|FileName", "KString", "", "", ""
+			P: "LastSaved", "Compound", "", ""
+			P: "LastSaved|ApplicationVendor", "KString", "", "", ""
+			P: "LastSaved|ApplicationName", "KString", "", "", ""
+			P: "LastSaved|ApplicationVersion", "KString", "", "", ""
+			P: "LastSaved|DateTime_GMT", "DateTime", "", "", ""
+		}
+	}
+}
+GlobalSettings:  {
+	Version: 1000
+	Properties70:  {
+		P: "UpAxis", "int", "Integer", "",1
+		P: "UpAxisSign", "int", "Integer", "",1
+		P: "FrontAxis", "int", "Integer", "",2
+		P: "FrontAxisSign", "int", "Integer", "",1
+		P: "CoordAxis", "int", "Integer", "",0
+		P: "CoordAxisSign", "int", "Integer", "",1
+		P: "OriginalUpAxis", "int", "Integer", "",-1
+		P: "OriginalUpAxisSign", "int", "Integer", "",1
+		P: "UnitScaleFactor", "double", "Number", "",1
+		P: "OriginalUnitScaleFactor", "double", "Number", "",1
+		P: "AmbientColor", "ColorRGB", "Color", "",0,0,0
+		P: "DefaultCamera", "KString", "", "", "Producer Perspective"
+		P: "TimeMode", "enum", "", "",11
+		P: "TimeProtocol", "enum", "", "",2
+		P: "SnapOnFrameMode", "enum", "", "",0
+		P: "TimeSpanStart", "KTime", "Time", "",46186158000
+		P: "TimeSpanStop", "KTime", "Time", "",11084677920000
+		P: "CustomFrameRate", "double", "Number", "",-1
+		P: "TimeMarker", "Compound", "", ""
+		P: "CurrentTimeMarker", "int", "Integer", "",-1
+	}
+}
+
+; Documents Description
+;------------------------------------------------------------------
+
+Documents:  {
+	Count: 1
+	Document: 140452948174272, "", "Scene" {
+		Properties70:  {
+			P: "SourceObject", "object", "", ""
+			P: "ActiveAnimStackName", "KString", "", "", ""
+		}
+		RootNode: 0
+	}
+}
+
+; Document References
+;------------------------------------------------------------------
+
+References:  {
+}
+
+; Object definitions
+;------------------------------------------------------------------
+
+Definitions:  {
+	Version: 100
+	Count: 49
+	ObjectType: "GlobalSettings" {
+		Count: 1
+	}
+	ObjectType: "Model" {
+		Count: 8
+		PropertyTemplate: "FbxNode" {
+			Properties70:  {
+				P: "QuaternionInterpolate", "enum", "", "",0
+				P: "RotationOffset", "Vector3D", "Vector", "",0,0,0
+				P: "RotationPivot", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingOffset", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingPivot", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationActive", "bool", "", "",0
+				P: "TranslationMin", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMax", "Vector3D", "Vector", "",0,0,0
+				P: "TranslationMinX", "bool", "", "",0
+				P: "TranslationMinY", "bool", "", "",0
+				P: "TranslationMinZ", "bool", "", "",0
+				P: "TranslationMaxX", "bool", "", "",0
+				P: "TranslationMaxY", "bool", "", "",0
+				P: "TranslationMaxZ", "bool", "", "",0
+				P: "RotationOrder", "enum", "", "",0
+				P: "RotationSpaceForLimitOnly", "bool", "", "",0
+				P: "RotationStiffnessX", "double", "Number", "",0
+				P: "RotationStiffnessY", "double", "Number", "",0
+				P: "RotationStiffnessZ", "double", "Number", "",0
+				P: "AxisLen", "double", "Number", "",10
+				P: "PreRotation", "Vector3D", "Vector", "",0,0,0
+				P: "PostRotation", "Vector3D", "Vector", "",0,0,0
+				P: "RotationActive", "bool", "", "",0
+				P: "RotationMin", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMax", "Vector3D", "Vector", "",0,0,0
+				P: "RotationMinX", "bool", "", "",0
+				P: "RotationMinY", "bool", "", "",0
+				P: "RotationMinZ", "bool", "", "",0
+				P: "RotationMaxX", "bool", "", "",0
+				P: "RotationMaxY", "bool", "", "",0
+				P: "RotationMaxZ", "bool", "", "",0
+				P: "InheritType", "enum", "", "",0
+				P: "ScalingActive", "bool", "", "",0
+				P: "ScalingMin", "Vector3D", "Vector", "",0,0,0
+				P: "ScalingMax", "Vector3D", "Vector", "",1,1,1
+				P: "ScalingMinX", "bool", "", "",0
+				P: "ScalingMinY", "bool", "", "",0
+				P: "ScalingMinZ", "bool", "", "",0
+				P: "ScalingMaxX", "bool", "", "",0
+				P: "ScalingMaxY", "bool", "", "",0
+				P: "ScalingMaxZ", "bool", "", "",0
+				P: "GeometricTranslation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricRotation", "Vector3D", "Vector", "",0,0,0
+				P: "GeometricScaling", "Vector3D", "Vector", "",1,1,1
+				P: "MinDampRangeX", "double", "Number", "",0
+				P: "MinDampRangeY", "double", "Number", "",0
+				P: "MinDampRangeZ", "double", "Number", "",0
+				P: "MaxDampRangeX", "double", "Number", "",0
+				P: "MaxDampRangeY", "double", "Number", "",0
+				P: "MaxDampRangeZ", "double", "Number", "",0
+				P: "MinDampStrengthX", "double", "Number", "",0
+				P: "MinDampStrengthY", "double", "Number", "",0
+				P: "MinDampStrengthZ", "double", "Number", "",0
+				P: "MaxDampStrengthX", "double", "Number", "",0
+				P: "MaxDampStrengthY", "double", "Number", "",0
+				P: "MaxDampStrengthZ", "double", "Number", "",0
+				P: "PreferedAngleX", "double", "Number", "",0
+				P: "PreferedAngleY", "double", "Number", "",0
+				P: "PreferedAngleZ", "double", "Number", "",0
+				P: "LookAtProperty", "object", "", ""
+				P: "UpVectorProperty", "object", "", ""
+				P: "Show", "bool", "", "",1
+				P: "NegativePercentShapeSupport", "bool", "", "",1
+				P: "DefaultAttributeIndex", "int", "Integer", "",-1
+				P: "Freeze", "bool", "", "",0
+				P: "LODBox", "bool", "", "",0
+				P: "Lcl Translation", "Lcl Translation", "", "A",0,0,0
+				P: "Lcl Rotation", "Lcl Rotation", "", "A",0,0,0
+				P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+				P: "Visibility", "Visibility", "", "A",1
+				P: "Visibility Inheritance", "Visibility Inheritance", "", "",1
+			}
+		}
+	}
+	ObjectType: "NodeAttribute" {
+		Count: 7
+		PropertyTemplate: "FbxNull" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "Size", "double", "Number", "",100
+				P: "Look", "enum", "", "",1
+			}
+		}
+	}
+	ObjectType: "Geometry" {
+		Count: 1
+		PropertyTemplate: "FbxMesh" {
+			Properties70:  {
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BBoxMin", "Vector3D", "Vector", "",0,0,0
+				P: "BBoxMax", "Vector3D", "Vector", "",0,0,0
+				P: "Primary Visibility", "bool", "", "",1
+				P: "Casts Shadows", "bool", "", "",1
+				P: "Receive Shadows", "bool", "", "",1
+			}
+		}
+	}
+	ObjectType: "AnimationStack" {
+		Count: 1
+		PropertyTemplate: "FbxAnimStack" {
+			Properties70:  {
+				P: "Description", "KString", "", "", ""
+				P: "LocalStart", "KTime", "Time", "",0
+				P: "LocalStop", "KTime", "Time", "",0
+				P: "ReferenceStart", "KTime", "Time", "",0
+				P: "ReferenceStop", "KTime", "Time", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationLayer" {
+		Count: 1
+		PropertyTemplate: "FbxAnimLayer" {
+			Properties70:  {
+				P: "Weight", "Number", "", "A",100
+				P: "Mute", "bool", "", "",0
+				P: "Solo", "bool", "", "",0
+				P: "Lock", "bool", "", "",0
+				P: "Color", "ColorRGB", "Color", "",0.8,0.8,0.8
+				P: "BlendMode", "enum", "", "",0
+				P: "RotationAccumulationMode", "enum", "", "",0
+				P: "ScaleAccumulationMode", "enum", "", "",0
+				P: "BlendModeBypass", "ULongLong", "", "",0
+			}
+		}
+	}
+	ObjectType: "AnimationCurveNode" {
+		Count: 6
+		PropertyTemplate: "FbxAnimCurveNode" {
+			Properties70:  {
+				P: "d", "Compound", "", ""
+			}
+		}
+	}
+	ObjectType: "AnimationCurve" {
+		Count: 18
+	}
+	ObjectType: "Deformer" {
+		Count: 5
+	}
+	ObjectType: "Pose" {
+		Count: 1
+	}
+}
+
+; Object properties
+;------------------------------------------------------------------
+
+Objects:  {
+	NodeAttribute: 140452949221776, "NodeAttribute::world_root", "Null" {
+		Properties70:  {
+			P: "Look", "enum", "", "",0
+		}
+		TypeFlags: "Null"
+	}
+	Geometry: 140452938475904, "Geometry::mesh", "Mesh" {
+		Vertices: *156 {
+			a: -0.5,0,-0.5,0.5,0,-0.5,0.5,0,0.5,-0.5,0,0.5,-0.5,1,-0.5,0.5,1,-0.5,0.5,1,0.5,-0.5,1,0.5,0.5,5.31280088424683,-0.5,0.5,5.31280088424683,0.5,-0.5,5.31280088424683,0.5,-0.5,5.31280088424683,-0.5,-0.5,0,1.57523274421692,-0.5,1,1.57523274421692,0.5,1,1.57523274421692,0.5,0,1.57523274421692,0.5,1.4312801361084,0.5,-0.5,1.4312801361084,0.5,0.5,1.8625602722168,0.5,-0.5,1.8625602722168,0.5,0.5,2.2938404083252,0.5,-0.5,2.2938404083252,0.5,0.5,2.72512054443359,0.5,-0.5,2.72512054443359,0.5,0.5,3.15640068054199,0.5,-0.5,3.15640068054199,0.5,0.5,3.58768081665039,0.5,-0.5,3.58768081665039,0.5,0.5,4.01896095275879,0.5,-0.5,4.01896095275879,0.5,0.5,4.45024108886719,0.5,-0.5,4.45024108886719,0.5,0.5,4.88152122497559,0.5,-0.5,4.88152122497559,0.5,-0.5,1.4312801361084,-0.5,-0.5,1.8625602722168,-0.5,-0.5,2.2938404083252,-0.5,-0.5,2.72512054443359,-0.5,-0.5,3.15640068054199,-0.5,-0.5,3.58768081665039,-0.5,-0.5,4.01896095275879,-0.5,-0.5,4.45024108886719,-0.5,-0.5,4.88152122497559,-0.5,0.5,1.4312801361084,-0.5,0.5,1.8625602722168,-0.5,0.5,2.2938404083252,-0.5,0.5,2.72512054443359,-0.5,0.5,3.15640068054199,-0.5,0.5,3.58768081665039,-0.5,0.5,4.01896095275879,-0.5,0.5,4.45024108886719,-0.5,0.5,4.88152122497559,-0.5
+		} 
+		PolygonVertexIndex: *200 {
+			a: 0,4,5,-2,1,5,6,-3,3,7,4,-1,3,0,1,-3,11,10,9,-9,15,14,13,-13,12,13,7,-4,13,14,6,-8,14,15,2,-7,15,12,3,-3,17,7,6,-17,19,17,16,-19,21,19,18,-21,23,21,20,-23,25,23,22,-25,27,25,24,-27,29,27,26,-29,31,29,28,-31,33,31,30,-33,32,9,10,-34,34,4,7,-18,35,34,17,-20,36,35,19,-22,37,36,21,-24,38,37,23,-26,39,38,25,-28,40,39,27,-30,41,40,29,-32,42,41,31,-34,33,10,11,-43,43,5,4,-35,44,43,34,-36,45,44,35,-37,46,45,36,-38,47,46,37,-39,48,47,38,-40,49,48,39,-41,50,49,40,-42,51,50,41,-43,42,11,8,-52,16,6,5,-44,18,16,43,-45,20,18,44,-46,22,20,45,-47,24,22,46,-48,26,24,47,-49,28,26,48,-50,30,28,49,-51,32,30,50,-52,51,8,9,-33
+		} 
+		GeometryVersion: 124
+		LayerElementNormal: 0 {
+			Version: 102
+			Name: "N"
+			MappingInformationType: "ByPolygon"
+			ReferenceInformationType: "Direct"
+			Normals: *150 {
+				a: 0,0,-1,1,0,0,-1,0,0,0,-1,0,0,1,0,0,0,1,-1,0,0,0,1,0,1,0,0,0,-1,0,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0.999999940395355,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-0.999999940395355,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,0,-0.999999940395355,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0.999999940395355,0,0
+			} 
+			NormalsW: *50 {
+				a: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+			} 
+		}
+		LayerElementColor: 0 {
+			Version: 101
+			Name: "Cd"
+			MappingInformationType: "ByPolygon"
+			ReferenceInformationType: "Direct"
+			Colors: *200 {
+				a: 0,0,1,1,1,0,0,1,1,0,0,1,0,1,0,1,0,1,0,1,0,0,1,1,1,0,0,1,0,1,0,1,1,0,0,1,0,1,0,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0.999999940395355,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,0.999999940395355,0,0,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,0.999999940395355,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,1,0,0,1,0.999999940395355,0,0,1
+			} 
+		}
+		LayerElementUserData: 0 {
+			Version: 101
+			Name: "UserDataLayer0"
+			MappingInformationType: "AllSame"
+			ReferenceInformationType: "Direct"
+			UserDataId: 0
+			UserDataArray:  {
+				UserDataType: "Float"
+				UserDataName: "pCaptFrame"
+				UserData: *1 {
+					a: 1
+				} 
+			}
+		}
+		Layer: 0 {
+			Version: 100
+			LayerElement:  {
+				Type: "LayerElementNormal"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementColor"
+				TypedIndex: 0
+			}
+			LayerElement:  {
+				Type: "LayerElementUserData"
+				TypedIndex: 0
+			}
+		}
+	}
+	NodeAttribute: 140452990134800, "NodeAttribute::root", "Null" {
+		TypeFlags: "Null"
+	}
+	NodeAttribute: 140452948093120, "NodeAttribute::bone1", "Root" {
+		TypeFlags: "Null", "Skeleton", "Root"
+	}
+	NodeAttribute: 140452995892016, "NodeAttribute::bone2", "LimbNode" {
+		TypeFlags: "Skeleton"
+	}
+	NodeAttribute: 140452943145568, "NodeAttribute::bone3", "LimbNode" {
+		TypeFlags: "Skeleton"
+	}
+	NodeAttribute: 140452971465152, "NodeAttribute::bone4", "LimbNode" {
+		TypeFlags: "Skeleton"
+	}
+	NodeAttribute: 140452943150464, "NodeAttribute::bone4_end_effector", "LimbNode" {
+		TypeFlags: "Skeleton"
+	}
+	Model: 140452983256576, "Model::world_root", "Null" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 140452743942656, "Model::mesh", "Mesh" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Visibility Inheritance", "Visibility Inheritance", "", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 140452979594240, "Model::root", "Null" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A",0,6.01473474502563,-2.01256275177002
+			P: "Visibility Inheritance", "Visibility Inheritance", "", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 140452977363456, "Model::bone1", "Root" {
+		Version: 232
+		Properties70:  {
+			P: "RotationOrder", "enum", "", "",5
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Rotation", "Lcl Rotation", "", "A",18.7982009690537,179.999994844218,179.999997878857
+			P: "Lcl Scaling", "Lcl Scaling", "", "A",1,0.999999984776801,0.999999984776801
+			P: "Visibility Inheritance", "Visibility Inheritance", "", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 140452938210304, "Model::bone2", "LimbNode" {
+		Version: 232
+		Properties70:  {
+			P: "RotationOrder", "enum", "", "",5
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A",1.94610103268145e-07,-7.26192777023016e-08,-2.16268591847666
+			P: "Lcl Rotation", "Lcl Rotation", "", "A",71.793087442368,5.03067387413121e-06,3.06003502936578e-06
+			P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1.00000002332392,1.00000002332392
+			P: "Visibility Inheritance", "Visibility Inheritance", "", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 140452743804416, "Model::bone3", "LimbNode" {
+		Version: 232
+		Properties70:  {
+			P: "RotationOrder", "enum", "", "",5
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A",1.87368184203859e-07,2.09820120652959e-09,-2.32034163016393
+			P: "Lcl Rotation", "Lcl Rotation", "", "A",-0.591288411422127,3.56750512476097e-07,-5.19875344178686e-08
+			P: "Lcl Scaling", "Lcl Scaling", "", "A",1,0.999999991899276,0.999999991899275
+			P: "Visibility Inheritance", "Visibility Inheritance", "", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 140452743952896, "Model::bone4", "LimbNode" {
+		Version: 232
+		Properties70:  {
+			P: "RotationOrder", "enum", "", "",5
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A",2.20850378457253e-07,9.65026669685898e-15,-2.52623376250266
+			P: "Lcl Rotation", "Lcl Rotation", "", "A",-79.9999999999998,1.5274149840555e-07,-7.65627377633972e-06
+			P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+			P: "Visibility Inheritance", "Visibility Inheritance", "", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Model: 140452477256704, "Model::bone4_end_effector", "LimbNode" {
+		Version: 232
+		Properties70:  {
+			P: "RotationActive", "bool", "", "",1
+			P: "InheritType", "enum", "", "",1
+			P: "ScalingMax", "Vector3D", "Vector", "",0,0,0
+			P: "DefaultAttributeIndex", "int", "Integer", "",0
+			P: "Lcl Translation", "Lcl Translation", "", "A",0,0,-1.58039259910583
+			P: "Visibility Inheritance", "Visibility Inheritance", "", "",0
+		}
+		Shading: Y
+		Culling: "CullingOff"
+	}
+	Pose: 140452950974480, "Pose::mesh", "BindPose" {
+		Type: "BindPose"
+		Version: 100
+		NbPoseNodes: 8
+		PoseNode:  {
+			Node: 0
+			Matrix: *16 {
+				a: 1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1
+			} 
+		}
+		PoseNode:  {
+			Node: 140452983256576
+			Matrix: *16 {
+				a: 1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1
+			} 
+		}
+		PoseNode:  {
+			Node: 140452979594240
+			Matrix: *16 {
+				a: 1,0,0,0,0,1,0,0,0,0,1,0,0,6.01473474502563,-2.01256275177002,1
+			} 
+		}
+		PoseNode:  {
+			Node: 140452977363456
+			Matrix: *16 {
+				a: 0.999999999999995,6.0496832380289e-09,9.71149705978034e-08,0,3.70209268081306e-08,-0.946659364062731,-0.322235966313427,0,8.99853735227214e-08,0.322235966313429,-0.946659364062726,0,0,6.01473474502563,-2.01256275177002,1
+			} 
+		}
+		PoseNode:  {
+			Node: 140452938210304
+			Matrix: *16 {
+				a: 0.999999999999996,-8.11963089024008e-08,4.28040363489265e-08,0,4.36396819992639e-08,0.0103197465123925,-0.999946758099334,0,8.07502577434883e-08,0.999946758099332,0.010319746512396,0,3.93259424429822e-16,5.31783962699858,0.0347641478830692,1
+			} 
+		}
+		PoseNode:  {
+			Node: 140452743804416
+			Matrix: *16 {
+				a: 0.999999999999995,-8.74227800037247e-08,4.37113900018624e-08,0,4.37113900018622e-08,-3.82333054105288e-15,-0.999999999999999,0,8.74227800037248e-08,0.999999999999996,1.73472347597681e-18,0,2.64697796016969e-23,2.99762153625488,0.0108188083395362,1
+			} 
+		}
+		PoseNode:  {
+			Node: 140452743952896
+			Matrix: *16 {
+				a: 0.999999999999997,4.37113900018624e-08,6.95408492289436e-08,0,5.51229575107911e-08,-0.984807753012207,-0.173648177666927,0,6.08939642546049e-08,0.17364817766693,-0.984807753012206,0,1.05879118406788e-22,0.471387773752213,0.0108188083395362,1
+			} 
+		}
+		PoseNode:  {
+			Node: 140452743942656
+			Matrix: *16 {
+				a: 1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1
+			} 
+		}
+	}
+	Deformer: 140452471472848, "Deformer::", "Skin" {
+		Version: 101
+		Link_DeformAcuracy: 50
+		SkinningType: "Linear"
+	}
+	Deformer: 140452471525344, "SubDeformer::", "Cluster" {
+		Version: 100
+		UserData: "", ""
+		Indexes: *13 {
+			a: 0,1,2,3,6,7,12,13,14,15,16,17,19
+		} 
+		Weights: *13 {
+			a: 0.5,0.5,1,1,0.548556864261627,0.55434787273407,1,0.969225466251373,0.982765972614288,1,0.138466164469719,0.170758664608002,0.000712834880687296
+		} 
+		Transform: *16 {
+			a: 0.999999998839336,4.37113906782531e-08,6.95408451888335e-08,0,4.37113906782533e-08,-0.999999998839336,-1.91361979417845e-16,0,6.95408475568158e-08,3.23108914511496e-15,-0.999999964787662,0,-2.13573558154686e-08,0.471387784535811,0.0108187352988623,1
+		} 
+		TransformLink: *16 {
+			a: 1.00000000116066,4.37113907797215e-08,6.95408477182424e-08,0,4.37113907797215e-08,-1.00000000116066,3.23108915261537e-15,0,6.95408500862249e-08,-1.91361992894451e-16,-1.00000003521233,0,-3.86791549552278e-15,0.471387785082934,0.0108187356798152,1
+		} 
+	}
+	Deformer: 140452950967024, "SubDeformer::", "Cluster" {
+		Version: 100
+		UserData: "", ""
+		Indexes: *30 {
+			a: 0,1,4,5,6,7,13,14,16,17,18,19,20,21,22,23,24,25,34,35,36,37,38,39,43,44,45,46,47,48
+		} 
+		Weights: *30 {
+			a: 0.5,0.5,1,1,0.45144310593605,0.44565212726593,0.0307745542377234,0.0172340553253889,0.86153382062912,0.829241335391998,1,0.999287188053131,0.97689950466156,1,0.772360384464264,0.786726415157318,0.346185028553009,0.245670050382614,1,1,1,0.8277547955513,0.326833069324493,0.00109193765092641,1,1,1,0.810589969158173,0.307815670967102,0.0233198832720518
+		} 
+		Transform: *16 {
+			a: 0.999999956623377,4.37113899031381e-08,8.7422774421285e-08,0,-8.74227744212851e-08,-3.76013880759974e-15,0.999999956623377,0,4.37113899031385e-08,-0.999999956623377,6.12323373013156e-17,0,2.61587477298034e-07,0.0108188075825666,-2.99762159437064,1
+		} 
+		TransformLink: *16 {
+			a: 1.00000004337662,-8.74227820054941e-08,4.37113936952432e-08,0,4.37113936952433e-08,-3.760139133804e-15,-1.00000004337662,0,8.74227820054943e-08,1.00000004337662,6.12323426134196e-17,0,2.53772585703869e-14,2.99762172439735,0.0108188080518387,1
+		} 
+	}
+	Deformer: 140452950969024, "SubDeformer::", "Cluster" {
+		Version: 100
+		UserData: "", ""
+		Indexes: *29 {
+			a: 8,9,10,11,20,22,23,24,25,26,27,28,29,30,31,32,33,37,38,39,40,41,42,46,47,48,49,50,51
+		} 
+		Weights: *29 {
+			a: 1,1,1,1,0.0231005121022463,0.227639615535736,0.213273569941521,0.653814911842346,0.754329979419708,1,1,1,1,1,1,1,1,0.172245234251022,0.673166930675507,0.998908042907715,1,1,1,0.189410045742989,0.692184329032898,0.976680099964142,1,1,1
+		} 
+		Transform: *16 {
+			a: 1.00000002827856,4.36396805435813e-08,8.07502608579233e-08,0,-8.11963154536138e-08,0.0103197467666703,0.999946727630989,0,4.28040353490156e-08,-0.999946757701318,0.0103197464563392,0,4.30300924480118e-07,-0.0201164550288303,-5.31791504889334,1
+		} 
+		TransformLink: *16 {
+			a: 0.999999971721429,-8.1196310861383e-08,4.28040329281421e-08,0,4.36396798710629e-08,0.0103197466076357,-0.999946742291431,0,8.07502644701366e-08,0.999946772361755,0.0103197469179739,0,9.97363296108912e-15,5.31783958555348,0.0347641537633147,1
+		} 
+	}
+	Deformer: 140452950970800, "SubDeformer::", "Cluster" {
+		Version: 100
+		UserData: "", ""
+		Transform: *16 {
+			a: 0.999999971554217,3.7020922183626e-08,8.99853641396799e-08,0,6.04968210640078e-09,-0.94665936965189,0.322235982215133,0,9.71149574613748e-08,-0.322235973727771,-0.946659394585907,0,1.59062720802321e-07,5.0453850316211,-3.84337541171404,1
+		} 
+		TransformLink: *16 {
+			a: 1.00000002844577,6.04968245057664e-09,9.7114962986396e-08,0,3.70209227421236e-08,-0.946659383933193,-0.322235978589023,0,8.99853607569578e-08,0.322235970101666,-0.946659358999169,0,-1.18393856313585e-14,6.01473488999875,-2.01256272062356,1
+		} 
+	}
+	AnimationStack: 140452966180704, "AnimStack::Main", "" {
+	}
+	AnimationLayer: 140452990124048, "AnimLayer::Base Layer", "" {
+	}
+	AnimationCurveNode: 140452990122608, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 140452471430048, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 140452471485664, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",1
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+	AnimationCurveNode: 140452951998048, "AnimCurveNode::T", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 140452471579968, "AnimCurveNode::R", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",0
+			P: "d|Y", "Number", "", "A",0
+			P: "d|Z", "Number", "", "A",0
+		}
+	}
+	AnimationCurveNode: 140452951074128, "AnimCurveNode::S", "" {
+		Properties70:  {
+			P: "d|X", "Number", "", "A",1
+			P: "d|Y", "Number", "", "A",1
+			P: "d|Z", "Number", "", "A",1
+		}
+	}
+}
+
+; Object connections
+;------------------------------------------------------------------
+
+Connections:  {
+	
+	;Model::world_root, Model::RootNode
+	C: "OO",140452983256576,0
+	
+	;NodeAttribute::world_root, Model::world_root
+	C: "OO",140452949221776,140452983256576
+	
+	;Model::mesh, Model::world_root
+	C: "OO",140452743942656,140452983256576
+	
+	;Model::root, Model::world_root
+	C: "OO",140452979594240,140452983256576
+	
+	;AnimCurveNode::T, Model::world_root
+	C: "OP",140452990122608,140452983256576, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::world_root
+	C: "OP",140452471430048,140452983256576, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::world_root
+	C: "OP",140452471485664,140452983256576, "Lcl Scaling"
+	
+	;Geometry::mesh, Model::mesh
+	C: "OO",140452938475904,140452743942656
+	
+	;AnimCurveNode::T, Model::mesh
+	C: "OP",140452951998048,140452743942656, "Lcl Translation"
+	
+	;AnimCurveNode::R, Model::mesh
+	C: "OP",140452471579968,140452743942656, "Lcl Rotation"
+	
+	;AnimCurveNode::S, Model::mesh
+	C: "OP",140452951074128,140452743942656, "Lcl Scaling"
+	
+	;Deformer::, Geometry::mesh
+	C: "OO",140452471472848,140452938475904
+	
+	;NodeAttribute::root, Model::root
+	C: "OO",140452990134800,140452979594240
+	
+	;Model::bone1, Model::root
+	C: "OO",140452977363456,140452979594240
+	
+	;NodeAttribute::bone1, Model::bone1
+	C: "OO",140452948093120,140452977363456
+	
+	;Model::bone2, Model::bone1
+	C: "OO",140452938210304,140452977363456
+	
+	;NodeAttribute::bone2, Model::bone2
+	C: "OO",140452995892016,140452938210304
+	
+	;Model::bone3, Model::bone2
+	C: "OO",140452743804416,140452938210304
+	
+	;NodeAttribute::bone3, Model::bone3
+	C: "OO",140452943145568,140452743804416
+	
+	;Model::bone4, Model::bone3
+	C: "OO",140452743952896,140452743804416
+	
+	;NodeAttribute::bone4, Model::bone4
+	C: "OO",140452971465152,140452743952896
+	
+	;Model::bone4_end_effector, Model::bone4
+	C: "OO",140452477256704,140452743952896
+	
+	;NodeAttribute::bone4_end_effector, Model::bone4_end_effector
+	C: "OO",140452943150464,140452477256704
+	
+	;AnimLayer::Base Layer, AnimStack::Main
+	C: "OO",140452990124048,140452966180704
+	
+	;AnimCurveNode::T, AnimLayer::Base Layer
+	C: "OO",140452990122608,140452990124048
+	
+	;AnimCurveNode::R, AnimLayer::Base Layer
+	C: "OO",140452471430048,140452990124048
+	
+	;AnimCurveNode::S, AnimLayer::Base Layer
+	C: "OO",140452471485664,140452990124048
+	
+	;AnimCurveNode::T, AnimLayer::Base Layer
+	C: "OO",140452951998048,140452990124048
+	
+	;AnimCurveNode::R, AnimLayer::Base Layer
+	C: "OO",140452471579968,140452990124048
+	
+	;AnimCurveNode::S, AnimLayer::Base Layer
+	C: "OO",140452951074128,140452990124048
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",140452938572272,140452990122608, "d|X"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",140452938452832,140452990122608, "d|Y"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",140452938470048,140452990122608, "d|Z"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",140452471438496,140452471430048, "d|X"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",140452471411520,140452471430048, "d|Y"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",140452951081840,140452471430048, "d|Z"
+	
+	;AnimCurve::, AnimCurveNode::S
+	C: "OP",140452471481808,140452471485664, "d|X"
+	
+	;AnimCurve::, AnimCurveNode::S
+	C: "OP",140452471528768,140452471485664, "d|Y"
+	
+	;AnimCurve::, AnimCurveNode::S
+	C: "OP",140452471473392,140452471485664, "d|Z"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",140452951084448,140452951998048, "d|X"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",140452471480016,140452951998048, "d|Y"
+	
+	;AnimCurve::, AnimCurveNode::T
+	C: "OP",140452471433280,140452951998048, "d|Z"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",140452951765216,140452471579968, "d|X"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",140452951072016,140452471579968, "d|Y"
+	
+	;AnimCurve::, AnimCurveNode::R
+	C: "OP",140452951073104,140452471579968, "d|Z"
+	
+	;AnimCurve::, AnimCurveNode::S
+	C: "OP",140452951079264,140452951074128, "d|X"
+	
+	;AnimCurve::, AnimCurveNode::S
+	C: "OP",140452951080592,140452951074128, "d|Y"
+	
+	;AnimCurve::, AnimCurveNode::S
+	C: "OP",140452951077040,140452951074128, "d|Z"
+	
+	;SubDeformer::, Deformer::
+	C: "OO",140452471525344,140452471472848
+	
+	;SubDeformer::, Deformer::
+	C: "OO",140452950967024,140452471472848
+	
+	;SubDeformer::, Deformer::
+	C: "OO",140452950969024,140452471472848
+	
+	;SubDeformer::, Deformer::
+	C: "OO",140452950970800,140452471472848
+	
+	;Model::bone4, SubDeformer::
+	C: "OO",140452743952896,140452471525344
+	
+	;Model::bone3, SubDeformer::
+	C: "OO",140452743804416,140452950967024
+	
+	;Model::bone2, SubDeformer::
+	C: "OO",140452938210304,140452950969024
+	
+	;Model::bone1, SubDeformer::
+	C: "OO",140452977363456,140452950970800
+}
+;Takes section
+;----------------------------------------------------
+
+Takes:  {
+	Current: ""
+	Take: "Main" {
+		FileName: "Main.tak"
+		LocalTime: 0,46186158000
+		ReferenceTime: 0,46186158000
+	}
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -247,7 +247,8 @@
                 "single-effector",
                 "single-target",
                 "multi-effector",
-                "readme-example"
+                "readme-example",
+								"skinned-mesh"
             ]
         };
 		function extractQuery() {

--- a/examples/scripts/AxisUtils.js
+++ b/examples/scripts/AxisUtils.js
@@ -1,0 +1,83 @@
+/**
+ * @author snayss -- https://codercat.tk
+ *
+ * Helper utility to iterate through a THREE.Bone heirarchy from a model
+ * created in an external software and set each bone +Z Forward vector to
+ * face the child bone.
+ *
+ **/
+
+const t = new THREE.Vector3();
+const q = new THREE.Quaternion();
+const p = new THREE.Plane();
+const FORWARD = new THREE.Vector3(0,0,1);
+var RESETQUAT = new THREE.Quaternion();
+
+/**
+* Takes in a rootBone and recursively traverses the bone heirarchy,
+* setting each bone's +Z axis to face it's child bones. The IK system follows this
+* convention, so this step is necessary to update the bindings of a skinned mesh.
+*
+* Must rebind the model to it's skeleton after this function.
+*
+* @param {THREE.BONE} rootBone
+*/
+
+function setZForward(rootBone) {
+  var worldPos = {};
+  getOriginalWorldPositions(rootBone, worldPos);
+  updateTransformations(rootBone, worldPos);
+}
+
+function updateTransformations(parentBone, worldPos) {
+
+    var averagedDir = new THREE.Vector3();
+    parentBone.children.forEach((childBone) => {
+      //average the child bone world pos
+      var childBonePosWorld = worldPos[childBone.id];
+      averagedDir.add(childBonePosWorld);
+    });
+
+    averagedDir.multiplyScalar(1/(parentBone.children.length));
+
+    //set quaternion
+    parentBone.quaternion.copy(RESETQUAT);
+    parentBone.updateMatrixWorld();
+    //get the child bone position in local coordinates
+    var childBoneDir = parentBone.worldToLocal(averagedDir).normalize();
+    //set the direction to child bone to the forward direction
+    var quat = getAlignmentQuaternion(FORWARD, childBoneDir);
+    if (quat) {
+      //rotate parent bone towards child bone
+      parentBone.quaternion.premultiply(quat);
+      parentBone.updateMatrixWorld();
+      //set child bone position relative to the new parent matrix.
+      parentBone.children.forEach((childBone) => {
+        var childBonePosWorld = worldPos[childBone.id].clone();
+        parentBone.worldToLocal(childBonePosWorld);
+        childBone.position.copy(childBonePosWorld);
+      });
+    }
+
+    parentBone.children.forEach((childBone) => {
+      updateTransformations(childBone, worldPos);
+    })
+}
+
+function getAlignmentQuaternion(fromDir, toDir) {
+  const adjustAxis = t.crossVectors(fromDir, toDir).normalize();
+  const adjustAngle = fromDir.angleTo(toDir);
+  if (adjustAngle) {
+    const adjustQuat = q.setFromAxisAngle(adjustAxis, adjustAngle);
+    return adjustQuat;
+  }
+  return null;
+}
+
+function getOriginalWorldPositions(rootBone, worldPos) {
+  rootBone.children.forEach((child) => {
+    var childWorldPos = child.getWorldPosition(new THREE.Vector3());
+    worldPos[child.id] = childWorldPos;
+    getOriginalWorldPositions(child, worldPos);
+  })
+}

--- a/examples/skinned-mesh.html
+++ b/examples/skinned-mesh.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>THREE.IK - skinned mesh test</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <style>
+        body {
+            font-family: Monospace;
+            background-color: #000;
+            color: #fff;
+            margin: 0px;
+            overflow: hidden;
+        }
+
+        #info {
+            color: #000;
+            position: absolute;
+            top: 10px;
+            width: 100%;
+            text-align: center;
+            z-index: 100;
+            display: block;
+        }
+
+        #info a {
+            color: #2fa1d6;
+            font-weight: bold;
+        }
+
+    </style>
+</head>
+
+<body>
+    <div id="info">
+      skinned mesh example by <a href="https://codercat.tk" target="_blank" rel="noopener">codercat</a>
+    </div>
+    <script src="node_modules/dat.gui/build/dat.gui.js"></script>
+    <script src="node_modules/three/build/three.js"></script>
+    <script src="node_modules/three/examples/js/controls/OrbitControls.js"></script>
+    <script src="node_modules/three/examples/js/loaders/FBXLoader.js"></script>
+    <script src="scripts/IKApp.js"></script>
+    <script src="scripts/AxisUtils.js"></script>
+
+    <script src="../build/three-ik.js"></script>
+    <script>
+        class SingleTargetApp extends IKApp {
+            setupGUI() {
+                this.config.constraintType = 'ball';
+                this.config.constraintAngle = 90;
+
+            }
+
+            setupIK() {
+
+                var fbxLoader = new THREE.FBXLoader();
+                fbxLoader.load('assets/rigTest-02.fbx', (rigGroup) => {
+                this.scene.add(rigGroup)
+                rigGroup.updateMatrixWorld()
+
+                var rigMesh = rigGroup.children[0];
+                var rootBone = rigGroup.children[1].children[0]
+
+                /**
+                  This model's bind matrices are -Z forward, while the IK system operates in +Z Forward -- assuming
+                  the parent's +Z forward faces the child. This utility helps us recalculate the models bone matrices
+                  to be consistent with the IK system.
+                 **/
+                setZForward(rootBone);
+                //must rebind the skeleton to reset the bind matrix.
+                rigMesh.bind(rigMesh.skeleton)
+
+                rigMesh.material = new THREE.MeshPhysicalMaterial({
+                  skinning: true,
+                  wireframe: true
+                })
+                this.target = new THREE.Object3D()
+                this.target.position.set(0,0,5)
+                this.scene.add(this.target)
+
+                var boneGroup = rootBone;
+                var ik = new IK.IK();
+                const chain = new IK.IKChain();
+                var currentBone = boneGroup
+                for (let i = 0; i < 5; i++) {
+                  var constraints = [new IK.IKBallConstraint(90)];
+                  const target = i === 4 ? this.target : null;
+                  chain.add(new IK.IKJoint(currentBone, { constraints }), { target });
+                  currentBone = currentBone.children[0]
+                }
+                ik.add(chain);
+                const helper = new IK.IKHelper(ik);
+                this.scene.add(helper);
+                this.iks.push(ik)
+
+              }, console.log, console.log);
+            }
+
+            onChange() {
+                super.onChange();
+            }
+
+            update() {
+              if(this.target){
+                this.target.position.y = 5 + Math.sin(0.005 * performance.now())
+              }
+            }
+        };
+
+        window.app = new SingleTargetApp();
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Hey @jsantell ,

Firstly, thanks for making this repo ~~

Secondly, I looked into integrating the three.ik system with the three.js skinned meshes / skeletons. Things looked really disastrous on the first try, the vertex points were completely out of place causing the bones to look dislocated. 

It was pretty clear that there was a discrepancy between the direction of the `IK.Joints` and the direction of the three.js bones. It may not have been apparent to you if you were testing using the helpers, because the helpers are designed relative to the direction between the `IK.Joints` anyways.

I've added a fix to the src files in this PR that addresses this fix by using the correct direction when applying the transformation to the three.js bone -- along with a small example for testing. 

Let me know what you think. 

If it looks alright, I can make a better example and we can add it to the page. 


