### PR TITLE
Update math module references and set minimum version for threejs

### DIFF
--- a/build/three-ik.module.js
+++ b/build/three-ik.module.js
@@ -1,4 +1,4 @@
-import { AxesHelper, Color, ConeBufferGeometry, Math as Math$1, Matrix4, Mesh, MeshBasicMaterial, Object3D, Vector3 } from 'three';
+import { AxesHelper, Color, ConeBufferGeometry, MathUtils as Math$1, Matrix4, Mesh, MeshBasicMaterial, Object3D, Vector3 } from 'three';
 
 var t1 = new Vector3();
 var t2 = new Vector3();

--- a/docs/IKBallConstraint.js.html
+++ b/docs/IKBallConstraint.js.html
@@ -26,7 +26,7 @@
     
     <section>
         <article>
-            <pre class="prettyprint source linenums"><code>import { Quaternion, Matrix4, Vector3, Math as ThreeMath } from 'three';
+            <pre class="prettyprint source linenums"><code>import { Quaternion, Matrix4, Vector3, MathUtils as ThreeMath } from 'three';
 import { transformPoint, getCentroid, getWorldPosition, setQuaternionFromDirection } from './utils.js';
 
 const Z_AXIS = new Vector3(0, 0, 1);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "three.js"
   ],
   "peerDependencies": {
-    "three": "*"
+    "three": "^0.125.0"
   },
   "repository": "https://github.com/jsantell/THREE.IK",
   "dependencies": {}

--- a/src/IKBallConstraint.js
+++ b/src/IKBallConstraint.js
@@ -1,4 +1,4 @@
-import { Vector3, Math as ThreeMath } from 'three';
+import { Vector3, MathUtils as ThreeMath } from 'three';
 import { transformPoint, getCentroid, getWorldPosition, setQuaternionFromDirection } from './utils.js';
 
 const Z_AXIS = new Vector3(0, 0, 1);


### PR DESCRIPTION
The math module was originally introduced in Three.js version r50 and was renamed to MathUtils in version r125. Using the old Math module is breaking the module imports in more recent versions of threejs. I updated the package's peer dependency version to match a minimum version of r125